### PR TITLE
zsh補完関数をコロン区切りCOWPATHに対応させた

### DIFF
--- a/compdef/_clangsay.zsh.src
+++ b/compdef/_clangsay.zsh.src
@@ -24,8 +24,11 @@ function _list_cowfile() {
         local COWPATH="_COWPATH"
     fi
 
-    _files -W `echo "$COWPATH" | sed 's/:/ /g'` && \
-        return 0;
+    for p in "${(ps.:.)COWPATH}"; do
+        for c in $(ls "${p}" 2>/dev/null); do
+            compadd "${c}"
+        done
+    done
 
     return 1;
 }


### PR DESCRIPTION
試したら上手くいったので送ります

![2017-05-15 18 43 59](https://cloud.githubusercontent.com/assets/4990822/26051902/aab73278-399e-11e7-848c-dc32178caef4.png)
