### PR TITLE
Dockerfileを追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine:latest
+
+COPY . /src
+
+RUN apk update && \
+    apk add --no-cache glib && \
+    apk add --no-cache --virtual depends \
+        make \
+        musl-dev \
+        glib-dev \
+        gcc && \
+    cd /src && \
+    make install && \
+    cd / && \
+    rm -rf /src && \
+    apk del --virtual depends
+
+ENTRYPOINT ["/usr/local/bin/clangsay"]

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ RM	:= rm
 CFLAGS	:= -O2 -g -Wall
 LDFLAGS	:=
 CMDLINE	:= 0
+DOCKER	:= docker
+IMGTAG	:= latest
 export
 
 all clean:
@@ -36,6 +38,9 @@ install: install-bin		\
 	 install-cows		\
 	 install-zsh-compdef
 
+docker-image:
+	@$(DOCKER) build -t clangsay:$(IMGTAG) .
+
 .PHONY: all			\
 	install			\
 	install-bin		\
@@ -44,4 +49,5 @@ install: install-bin		\
 	install-cows-asciiart	\
 	install-cows-pixelart	\
 	install-zsh-compdef	\
-	clean
+	clean			\
+	docker-image

--- a/README.md
+++ b/README.md
@@ -48,6 +48,29 @@ zsh completion has been installed to:
 
 このパスを`$fpath`に追加するか、既にパスの通っている任意のディレクトリに`_clangsay`を移動して下さい。
 
+#### Docker
+
+ビルド済みバイナリとcowfileがバンドルされたイメージを生成するための `Dockerfile` が同梱されています。
+
+```shellsession
+% HEAD=`git rev-parse --short HEAD`
+% make docker-image IMGTAG=$HEAD
+% yasuna | docker run --rm -i clangsay:$HEAD -f yasuna_16
+ _______________________
+< 自分でやったんじゃん！ >
+ -----------------------
+   \
+    \
+         ..: ￣￣￣￣: :.
+       ／::  /｜.:/ |.: .:＼
+      ,  /｜/  |./  |.ﾊ.: .:ヽ
+    ./.:ｲ__ノ   ヽ､___∨.: .:.
+   ./: .:≡≡     ≡≡.|.: .:｜
+   /ノ|/} }.      } } |:ﾊ:.:｜
+     .ヽ{,{ -~~~- {,{｜:/ﾉ:从
+      ∨v､＞z-r-x-:r＜/ﾚﾚへ
+```
+
 #### Other systems.
 
 * 全てインストールする場合	


### PR DESCRIPTION
![](http://www.mpgr.jp/data/mpgr/_/70726f647563742f73616d706c652f73616d2d7365616c2d33322e6a7067003230300000660023666666666666.jpg)

依存パッケージを準備しなくても、イメージをビルドすれば `clangsay` を動かすことの出来る `Dockerfile` を追加しました。

生成後のイメージサイズは10.5MBです。