### PR TITLE
Dockerfile: マルチステージビルドを使用することでイメージサイズを削減

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,3 +17,4 @@
   cows/pixelart/doseisan.cow
   cows/pixelart/yurushite.cow
   cows/pixelart/yunocchi.cow
+  cows/pixelart/chara.cow

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,17 @@
-FROM alpine:latest
+# build stage
+FROM alpine:3.8 as build
 
 COPY . /src
+WORKDIR /src
 
-RUN apk update && \
-    apk add --no-cache glib && \
-    apk add --no-cache --virtual depends \
-        make \
-        musl-dev \
-        glib-dev \
-        gcc && \
-    cd /src && \
-    make install && \
-    cd / && \
-    rm -rf /src && \
-    apk del --virtual depends
+RUN apk update
+RUN apk add gcc make pkgconf glib-dev musl-dev
+RUN make WITH_GLIB=0 WITH_REGEX=0 WITH_GNU=0 install-bin install-cows
+
+# runtime stage
+FROM alpine:3.8
+
+COPY --from=build /usr/local/bin/clangsay /usr/local/bin/clangsay
+COPY --from=build /usr/local/share/clangsay/cows /usr/local/share/clangsay/cows
 
 ENTRYPOINT ["/usr/local/bin/clangsay"]

--- a/README.md
+++ b/README.md
@@ -53,23 +53,6 @@ EOF
 詳しい情報については[Debian 新メンテナーガイド 日本語版](https://www.debian.org/doc/manuals/maint-guide/index.ja.html)をご覧下さい。
 
 
-### Mac OS X/Homebrew
-
-依存パッケージとして cowsay、pkg-config、glib がインストールされます。	
-
-```shellsession
-% brew install 844196/Renge/clangsay
-```
-
-上記のコマンドを実行した際に、補完関数をインストールしたディレクトリを示す下記のようなメッセージが出ます。
-
-```shellsession
-zsh completion has been installed to:
-/usr/local/share/zsh/site-functions	# Homebrewの導入先により異なります
-```
-
-このパスを`$fpath`に追加するか、既にパスの通っている任意のディレクトリに`_clangsay`を移動して下さい。
-
 ### Docker
 
 ビルド済みバイナリと cowfile がバンドルされたイメージを生成するための `Dockerfile` が同梱されています。


### PR DESCRIPTION
```console
% docker images clangsay | docker run -i --rm clangsay:new -f hiyoko --think -R 3
 _______________________________________________________________________________________________
/  ___________________________________________________________________________________________   \
| /  _______________________________________________________________________________________   \ |
| | / REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE   \ | |
| | | clangsay            new                 1f879351a5e8        41 minutes ago      4.85MB | | |
| | \ clangsay            old                 cdee2f23b964        42 minutes ago      11.7MB / | |
| \  ---------------------------------------------------------------------------------------   / |
\  -------------------------------------------------------------------------------------------   /
 -----------------------------------------------------------------------------------------------
  o
   o
    o
      ,､ ,._
      ﾉ ・  ヽ
     / :::   i
    / :::    ﾞ､
   ,i:::       `ｰ-､
   |:::           i
   !::::..        ﾉ
    `ー――――'"
```

ランタイムステージにビルド結果（バイナリとcowファイル）のみをコピーすることで、ビルド後のイメージサイズを半分にできました。

> 今まで使用できないzsh補完関数やmanまでイメージに含まれてたのは内緒。

---

![bb3](https://user-images.githubusercontent.com/4990822/49301146-4b32d980-f507-11e8-9174-9487c8db0a48.jpg)

もう3年ほどメンテナンスをしていないのでHomebrewでのインストール方法セクションを削除しました。